### PR TITLE
Fixed tag urls on the single page templates.

### DIFF
--- a/govintranet/single-blog.php
+++ b/govintranet/single-blog.php
@@ -100,8 +100,8 @@ get_header(); ?>
 			  	foreach($posttags as $tag) {
 			  		if (substr($tag->name,0,9)!="carousel:"){
 			  			$foundtags=true;
-			  			$tagurl = $tag->slug;
-				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl) . "?post_type=blog'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
+			  			$tagurl = $tag->term_id;
+				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl)."?type=blog'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
 			    	}
 			  	}
 			  	if ($foundtags){

--- a/govintranet/single-event.php
+++ b/govintranet/single-event.php
@@ -175,8 +175,8 @@ $mainid=$post->ID;
 		$tagstr="";
 	  	foreach($posttags as $tag) { 
 	  			$foundtags=true;
-	  			$tagurl = $tag->slug;
-		    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl) . "?type=event'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
+	  			$tagurl = $tag->term_id;
+		    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl)."?type=event'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
 	  	}
 	  	if ($foundtags){
 		  	echo "<div class='widget-box'><h3>" . __('Tags' , 'govintranet') . "</h3><p> "; 

--- a/govintranet/single-news.php
+++ b/govintranet/single-news.php
@@ -114,8 +114,8 @@ remove_filter('pre_get_posts', 'filter_search');
 					$tagstr="";
 				  	foreach( $posttags as $tag ) {
 			  			$foundtags=true;
-			  			$tagurl = $tag->slug;
-				    	$tagstr=$tagstr."<span><a class='label label-default' href='".site_url()."/tag/{$tagurl}/?type=news'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
+			  			$tagurl = $tag->term_id;
+				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl)."?type=news'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
 				  	}
 				  	if ( $foundtags ){
 					  	echo "<div class='widget-box'><h3>" . __('Tags' , 'govintranet') . "</h3><p> "; 

--- a/govintranet/single-project.php
+++ b/govintranet/single-project.php
@@ -229,8 +229,8 @@ if ( have_posts() ) while ( have_posts() ) : the_post();
 			  	foreach($posttags as $tag) {
 			  		if (substr($tag->name,0,9)!="carousel:"){
 			  			$foundtags=true;
-			  			$tagurl = $tag->slug;
-				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tag->slug)."?type=project'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
+			  			$tagurl = $tag->term_id;
+				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl)."?type=project'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
 			    	}
 			  	}
 			  	if ($foundtags){

--- a/govintranet/single-vacancy.php
+++ b/govintranet/single-vacancy.php
@@ -121,7 +121,7 @@ $current_vac = $id;
 			  	foreach($posttags as $tag) {
 			  		if (substr($tag->name,0,9)!="carousel:"){
 			  			$foundtags=true;
-			  			$tagurl = $tag->slug;
+			  			$tagurl = $tag->term_id;
 				    	$tagstr=$tagstr."<span><a class='label label-default' href='".get_tag_link($tagurl)."/?type=vacancy'>" . str_replace(' ', '&nbsp' , $tag->name) . '</a></span> '; 
 			    	}
 			  	}


### PR DESCRIPTION
The URLs on the tag widget on the single page templates was broken. 

This was because the `get_tag_link()` function was being passed the tag's slug when it requires the term id. please see: https://codex.wordpress.org/Function_Reference/get_tag_link.

`govintranet/single-blog.php` was using the query `?post_type` instead of the correct `?post`.

`govintranet/single-news.php` I've used the `get_tag_link()` method because it's more reliable. 
