### PR TITLE
Add `package.json` to specify a LESS version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# npm
+node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "govintranet",
+  "version": "1.0.0",
+  "description": "Govintranet Wordpress Theme and Plugins",
+  "private": true,
+  "author": "HelpfulClients & Bang",
+  "license": "GPL",
+  "dependencies": {},
+  "devDependencies": {
+    "less": "2.5.3"
+  }
+}


### PR DESCRIPTION
**Why is this change necessary?**
- Bang's `local-update.sh` uses the `lessc` node module to compile
  `.less` stylesheets in both themes and plugins.
- The `govintranet` theme itself doesn't currently use a preprocessor.
  If it does then we don't have the src files, but we're likely using
  plugins from `bangwordpress` that do.
- We're therefore unlikely to be able to convince govintranet to take
  this change in the upstream.
- LESS has also been known to have bugs between versions in the past.

**How does it address the issue?**
- Adds a `package.json` fixing the LESS version to 2.5.3 (latest stable).
- Updates the `.gitignore` to ignore the neccessary npm artefacts.
