### PR TITLE
Add basic `.editorconfig` to prevent `trim_trailing_whitespace`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = false


### PR DESCRIPTION
**Because:**
- The helpful clients project isn't consistent when it comes to trailing whitespace.
- Most Bang devs have their editors defaulting to trim the trailing whitespace.
- That causes lots of noise in the diffs, which makes taking future upstream changes more problematic.

**This change:**
- Adds a basic `.editorconfig` to prevent `trim_trailing_whitespace`

**Notes:**
- Requires the EditorConfig plugin to be installed and enabled in your editor: http://editorconfig.org/#download
- `trim_trailing_whitespace` is currently unsupported in the atom plugin, so Atom users will need to manage this themselves ref: https://github.com/sindresorhus/atom-editorconfig/issues/3
